### PR TITLE
Allow specification of the start location from Archipelago

### DIFF
--- a/mod/ArchipelagoHylics2.csproj
+++ b/mod/ArchipelagoHylics2.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>ArchipelagoHylics2</AssemblyName>
     <Description>Connect to an Archipelago server to play Hylics 2 Randomizer.</Description>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <PlatformTarget>x86</PlatformTarget>

--- a/mod/Data.cs
+++ b/mod/Data.cs
@@ -10,7 +10,6 @@ namespace ArchipelagoHylics2
         public string password;
         public bool party_shuffle = false;
         public bool medallion_shuffle = false;
-        public bool random_start = false;
         public string start_location = "?";
         public bool visited_waynehouse = false;
         public bool death_link = false;

--- a/mod/Main.cs
+++ b/mod/Main.cs
@@ -18,7 +18,7 @@ namespace ArchipelagoHylics2
     {
         public const string PluginGUID = "com.trpg.ArchipelagoHylics2";
         public const string PluginName = "ArchipelagoHylics2";
-        public const string PluginVersion = "1.0.8";
+        public const string PluginVersion = "1.0.9";
 
         public static Harmony harmony = new("mod.ArchipelagoHylics2");
 
@@ -509,26 +509,23 @@ namespace ArchipelagoHylics2
                                     Quaternion q = new(0, 0.3827f, 0, 0.9239f);
                                     Vector3 w3 = new(-24.3298f, 16f, -57.7844f);
 
-                                    if (APState.ServerData.random_start)
+                                    if (APState.ServerData.start_location == "Viewax's Edifice")
                                     {
-                                        if (APState.ServerData.start_location == "Viewax's Edifice")
-                                        {
-                                            v3 = new(66.5159f, 6.2685f, -12.0272f);
-                                            q = new(0, 0.8808f, 0, 0.4724f);
-                                            w3 = new(65.05f, 5.6f, -11.176f);
-                                        }
-                                        if (APState.ServerData.start_location == "TV Island")
-                                        {
-                                            v3 = new(125.4f, 5.3839f, 121.033f);
-                                            q = new(0, 0.9849f, 0, -0.1729f);
-                                            w3 = new(126.115f, 4.85f, 123.23f);
-                                        }
-                                        if (APState.ServerData.start_location == "Shield Facility")
-                                        {
-                                            v3 = new(-116.3876f, 6.2785f, 45.9867f);
-                                            q = new(0, 0.9931f, 0, -0.1176f);
-                                            w3 = new(-116.168f, 5.65f, 47.49f);
-                                        }
+                                        v3 = new(66.5159f, 6.2685f, -12.0272f);
+                                        q = new(0, 0.8808f, 0, 0.4724f);
+                                        w3 = new(65.05f, 5.6f, -11.176f);
+                                    }
+                                    if (APState.ServerData.start_location == "TV Island")
+                                    {
+                                        v3 = new(125.4f, 5.3839f, 121.033f);
+                                        q = new(0, 0.9849f, 0, -0.1729f);
+                                        w3 = new(126.115f, 4.85f, 123.23f);
+                                    }
+                                    if (APState.ServerData.start_location == "Shield Facility")
+                                    {
+                                        v3 = new(-116.3876f, 6.2785f, 45.9867f);
+                                        q = new(0, 0.9931f, 0, -0.1176f);
+                                        w3 = new(-116.168f, 5.65f, 47.49f);
                                     }
 
                                     obj.transform.SetPositionAndRotation(v3, q);
@@ -827,28 +824,28 @@ namespace ArchipelagoHylics2
 
                         if (command == "home")
                         {
-                            if (APState.ServerData.random_start && APState.ServerData.start_location == "Viewax's Edifice")
+                            if (APState.ServerData.start_location == "Viewax's Edifice")
                             {
                                 target.spawnID = 9;
                                 target.sceneName = "BanditFort_Scene";
                                 changer.target = new[] { target };
                                 changer.StartEvent(gameObject);
                             }
-                            else if (APState.ServerData.random_start && APState.ServerData.start_location == "TV Island")
+                            else if (APState.ServerData.start_location == "TV Island")
                             {
                                 target.spawnID = 9;
                                 target.sceneName = "BigTV_Island_Scene";
                                 changer.target = new[] { target };
                                 changer.StartEvent(gameObject);
                             }
-                            else if (APState.ServerData.random_start && APState.ServerData.start_location == "Shield Facility")
+                            else if (APState.ServerData.start_location == "Shield Facility")
                             {
                                 target.spawnID = 9;
                                 target.sceneName = "WormRoom_Scene";
                                 changer.target = new[] { target };
                                 changer.StartEvent(gameObject);
                             }
-                            else
+                            else if (APState.ServerData.start_location == "Waynehouse")
                             {
                                 target.spawnID = 0;
                                 target.sceneName = "StartHouse_Room1";
@@ -948,7 +945,7 @@ namespace ArchipelagoHylics2
             foreach (GameObject obj in objectList)
             {
                 // move airship if random start is enabled
-                if ((obj.name == "AirshipModel_Prefab" || obj.name == "AirshipModel_Prefab(Clone)") && APState.ServerData.random_start && APState.ServerData.start_location != "Waynehouse"
+                if ((obj.name == "AirshipModel_Prefab" || obj.name == "AirshipModel_Prefab(Clone)") && APState.ServerData.start_location != "Waynehouse"
                     && !ORK.Game.Variables.GetBool("AirshipEnteredNormallyAtLeastOnce"))
                 {
                     if (APState.ServerData.start_location == "Viewax's Edifice")
@@ -1145,7 +1142,7 @@ namespace ArchipelagoHylics2
                             break;
 
                         case "AfterlifeWarpChoice_Event": // Talk to guy in Afterlife next to pool
-                            if (APState.ServerData.random_start && APState.ServerData.start_location != "Waynehouse" && !APState.ServerData.visited_waynehouse)
+                            if (APState.ServerData.start_location != "Waynehouse" && !APState.ServerData.visited_waynehouse)
                             {
                                 if (xml.Contains("Waynehouse"))
                                 {
@@ -1156,7 +1153,7 @@ namespace ArchipelagoHylics2
                             break;
 
                         case "Afterlife_WarpPool_SceneChangerEvent": // Jump in pool in Afterlife
-                            if (APState.ServerData.random_start && APState.ServerData.start_location != "Waynehouse" && !APState.ServerData.visited_waynehouse)
+                            if (APState.ServerData.start_location != "Waynehouse" && !APState.ServerData.visited_waynehouse)
                             {
                                 if (xml.Contains("StartHouse_Room1"))
                                 {

--- a/mod/State.cs
+++ b/mod/State.cs
@@ -74,52 +74,47 @@ namespace ArchipelagoHylics2
                         APH2Plugin.ReloadEvents();
                     }
                 }
-                if (loginSuccess.SlotData["random_start"].ToString() == "1")
+                ServerData.start_location = loginSuccess.SlotData["start_location"].ToString();
+                if ((ServerData.checked_waynehouse + ServerData.checked_afterlife + ServerData.checked_new_muldul + ServerData.checked_new_muldul_vault + 
+                    ServerData.checked_pongorma + ServerData.checked_blerol1 + ServerData.checked_blerol2 + ServerData.checked_viewaxs_edifice + 
+                    ServerData.checked_arcade1 + ServerData.checked_airship + ServerData.checked_arcade_island + ServerData.checked_arcade2 + 
+                    ServerData.checked_tv_island + ServerData.checked_juice_ranch + ServerData.checked_worm_pod + ServerData.checked_foglast + 
+                    ServerData.checked_drill_castle + ServerData.checked_sage_labyrinth + ServerData.checked_sage_airship + ServerData.checked_hylemxylem) == 0
+                    && ServerData.start_location != "Waynehouse")
                 {
-                    ServerData.random_start = true;
-                    ServerData.start_location = loginSuccess.SlotData["start_location"].ToString();
-
-                    if ((ServerData.checked_waynehouse + ServerData.checked_afterlife + ServerData.checked_new_muldul + ServerData.checked_new_muldul_vault + 
-                        ServerData.checked_pongorma + ServerData.checked_blerol1 + ServerData.checked_blerol2 + ServerData.checked_viewaxs_edifice + 
-                        ServerData.checked_arcade1 + ServerData.checked_airship + ServerData.checked_arcade_island + ServerData.checked_arcade2 + 
-                        ServerData.checked_tv_island + ServerData.checked_juice_ranch + ServerData.checked_worm_pod + ServerData.checked_foglast + 
-                        ServerData.checked_drill_castle + ServerData.checked_sage_labyrinth + ServerData.checked_sage_airship + ServerData.checked_hylemxylem) == 0 
-                        && ServerData.start_location != "Waynehouse")
+                    // remove mini crystal from inventory if random start is enabled and start location is not Waynehouse
+                    if (ORK.Game.ActiveGroup.Leader.Inventory.Has(new ItemShortcut(15, 1)))
                     {
-                        // remove mini crystal from inventory if random start is enabled and start location is not Waynehouse
-                        if (ORK.Game.ActiveGroup.Leader.Inventory.Has(new ItemShortcut(15, 1)))
-                        {
-                            ORK.Game.ActiveGroup.Leader.Inventory.Remove(new ItemShortcut(15, 1), false, false);
-                        }
-
-                        GameObject gameObject = new("Changer");
-                        SceneChanger changer = gameObject.AddComponent<SceneChanger>();
-                        SceneTarget target = new();
-                        target.spawnID = 9;
-
-                        if (ServerData.start_location == "Viewax's Edifice")
-                        {
-                            ORK.Game.Variables.Set("Warp3_Fort", true);
-                            target.sceneName = "BanditFort_Scene";
-                            changer.target = new[] { target };
-                            changer.StartEvent(gameObject);
-                        }
-                        else if (ServerData.start_location == "TV Island")
-                        {
-                            ORK.Game.Variables.Set("Warp60_BigTV", true);
-                            target.sceneName = "BigTV_Island_Scene";
-                            changer.target = new[] { target };
-                            changer.StartEvent(gameObject);
-                        }
-                        else if (ServerData.start_location == "Shield Facility")
-                        {
-                            ORK.Game.Variables.Set("Warp100_WormHouse", true);
-                            target.sceneName = "WormRoom_Scene";
-                            changer.target = new[] { target };
-                            changer.StartEvent(gameObject);
-                        }
-                        ServerData.visited_waynehouse = false;
+                        ORK.Game.ActiveGroup.Leader.Inventory.Remove(new ItemShortcut(15, 1), false, false);
                     }
+
+                    GameObject gameObject = new("Changer");
+                    SceneChanger changer = gameObject.AddComponent<SceneChanger>();
+                    SceneTarget target = new();
+                    target.spawnID = 9;
+
+                    if (ServerData.start_location == "Viewax's Edifice")
+                    {
+                        ORK.Game.Variables.Set("Warp3_Fort", true);
+                        target.sceneName = "BanditFort_Scene";
+                        changer.target = new[] { target };
+                        changer.StartEvent(gameObject);
+                    }
+                    else if (ServerData.start_location == "TV Island")
+                    {
+                        ORK.Game.Variables.Set("Warp60_BigTV", true);
+                        target.sceneName = "BigTV_Island_Scene";
+                        changer.target = new[] { target };
+                        changer.StartEvent(gameObject);
+                    }
+                    else if (ServerData.start_location == "Shield Facility")
+                    {
+                        ORK.Game.Variables.Set("Warp100_WormHouse", true);
+                        target.sceneName = "WormRoom_Scene";
+                        changer.target = new[] { target };
+                        changer.StartEvent(gameObject);
+                    }
+                    ServerData.visited_waynehouse = false;
                 }
                 if (loginSuccess.SlotData["death_link"].ToString() == "1") ServerData.death_link = true;
                 set_deathlink();


### PR DESCRIPTION
Removes the Random Start option from archipelago in favor of the Start Location option. This, in addition to allowing the player to pick a random starting location, also allows them to specify which of the start locations they would like to have.

See https://github.com/ArchipelagoMW/Archipelago/pull/3289